### PR TITLE
Different provider support

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -4,5 +4,5 @@ config :fire_saga,
   openai_ttt: System.get_env("OPENAI_TTT_URL") || "https://api.openai.com/v1/chat/completions",
   openai_tti: System.get_env("OPENAI_TTI_URL") || "https://api.openai.com/v1/images/generations",
   openai_ttt_api: System.get_env("OPENAI_TTT_API"),
-  openai_tti_api: System.get_env("OPENAI_TTI_API") || openai_ttt_api,
+  openai_tti_api: System.get_env("OPENAI_TTI_API"),
   openai_org_id: System.get_env("OPENAI_ORG_ID")

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,5 +1,7 @@
 import Config
 
 config :fire_saga,
+  openai_ttt: System.get_env("OPENAI_TTT_URL")
+  openai_tti: System.get_env("OPENAI_TTI_URL"),
   openai_api_key: System.get_env("OPENAI_API_KEY"),
   openai_org_id: System.get_env("OPENAI_ORG_ID")

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :fire_saga,
-  openai_ttt: System.get_env("OPENAI_TTT_URL")
-  openai_tti: System.get_env("OPENAI_TTI_URL"),
+  openai_ttt: System.get_env("OPENAI_TTT_URL") || "https://api.openai.com/v1/chat/completions",
+  openai_tti: System.get_env("OPENAI_TTI_URL") || "https://api.openai.com/v1/images/generations",
   openai_api_key: System.get_env("OPENAI_API_KEY"),
   openai_org_id: System.get_env("OPENAI_ORG_ID")

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -3,5 +3,6 @@ import Config
 config :fire_saga,
   openai_ttt: System.get_env("OPENAI_TTT_URL") || "https://api.openai.com/v1/chat/completions",
   openai_tti: System.get_env("OPENAI_TTI_URL") || "https://api.openai.com/v1/images/generations",
-  openai_api_key: System.get_env("OPENAI_API_KEY"),
+  openai_ttt_api: System.get_env("OPENAI_TTT_API"),
+  openai_tti_api: System.get_env("OPENAI_TTI_API") || openai_ttt_api,
   openai_org_id: System.get_env("OPENAI_ORG_ID")

--- a/lib/fire_saga/llm.ex
+++ b/lib/fire_saga/llm.ex
@@ -2,7 +2,7 @@ defmodule FireSaga.LLM do
   def chat!(prompt) do
     body = %{model: "gpt-4o-mini", messages: [%{role: "user", content: prompt}]}
 
-    case post(json: body, url: "https://api.openai.com/v1/chat/completions") do
+    case post(json: body, url: Application.fetch_env!(:fire_saga, :openai_ttt)) do
       {:ok, %{body: body}} -> get_in(body, ["choices", Access.at(0), "message", "content"])
       error -> raise error
     end
@@ -11,7 +11,7 @@ defmodule FireSaga.LLM do
   def image!(prompt) do
     body = %{model: "dall-e-3", prompt: prompt, size: "1024x1024"}
 
-    case post(json: body, url: "https://api.openai.com/v1/images/generations") do
+    case post(json: body, url: Application.fetch_env!(:fire_saga, :openai_tti)) do
       {:ok, %{body: body, status: 200}} -> get_in(body, ["data", Access.at(0), "url"])
       error -> raise error
     end

--- a/lib/fire_saga/llm.ex
+++ b/lib/fire_saga/llm.ex
@@ -1,8 +1,7 @@
 defmodule FireSaga.LLM do
   def chat!(prompt) do
     body = %{model: "gpt-4o-mini", messages: [%{role: "user", content: prompt}]}
-
-    case post(json: body, url: Application.fetch_env!(:fire_saga, :openai_ttt)) do
+    case post(:ttt, json: body) do
       {:ok, %{body: body}} -> get_in(body, ["choices", Access.at(0), "message", "content"])
       error -> raise error
     end
@@ -10,25 +9,33 @@ defmodule FireSaga.LLM do
 
   def image!(prompt) do
     body = %{model: "dall-e-3", prompt: prompt, size: "1024x1024"}
-
-    case post(json: body, url: Application.fetch_env!(:fire_saga, :openai_tti)) do
+    case post(:tti, json: body) do
       {:ok, %{body: body, status: 200}} -> get_in(body, ["data", Access.at(0), "url"])
       error -> raise error
     end
   end
 
-  defp post(opts) do
-    api_key = Application.fetch_env!(:fire_saga, :openai_api_key)
-    oorg_id = Application.fetch_env!(:fire_saga, :openai_org_id)
+  defp post(:ttt, opts) do
+    api_key = Application.fetch_env!(:fire_saga, :openai_ttt_api)
+    url = Application.fetch_env!(:fire_saga, :openai_ttt)
+    post_request(opts, api_key, url)
+  end
 
+  defp post(:tti, opts) do
+    api_key = Application.fetch_env!(:fire_saga, :openai_tti_api)
+    url = Application.fetch_env!(:fire_saga, :openai_tti)
+    post_request(opts, api_key, url)
+  end
+
+  defp post_request(opts, api_key, url) do
+    oorg_id = Application.fetch_env!(:fire_saga, :openai_org_id)
     defaults = [
+      url: url,
       auth: {:bearer, api_key},
       headers: %{"openai-organization" => oorg_id},
       receive_timeout: 60_000
     ]
-
     app_opts = Application.get_env(:fire_saga, __MODULE__, [])
-
     opts
     |> Keyword.merge(defaults)
     |> Keyword.merge(app_opts)


### PR DESCRIPTION
This allows for the option of different providers to be used apart from openai. This works by allowing providers with the same api structure as openai to be used instead of only openai. If no values are set, it defaults to openai endpoints. This is for both text-to-text (ttt) and text-to-image (tti).
